### PR TITLE
Añade logo a favicon y footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <meta name="keywords" content="portafolio, Yeray, desarrollador, ingeniería informática, python, web, datos">
   <title>Yeray | Portfolio</title>
 
-  <link rel="icon" href="favicon.ico">
+  <link rel="icon" type="image/png" href="features/logo.png">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Poppins:wght@400;700&display=swap" rel="stylesheet">
@@ -182,6 +182,7 @@
 
   <footer>
     <div class="footer-left">
+      <img src="features/logo.png" alt="Logo" class="footer-logo">
       <a href="https://github.com/YerayAR" aria-label="GitHub" class="social-link">
         <svg class="social-icon" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>GitHub</title><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
       </a>

--- a/style.css
+++ b/style.css
@@ -290,6 +290,11 @@ footer {
   fill: var(--accent-color);
 }
 
+.footer-logo {
+  width: 40px;
+  height: auto;
+}
+
 .footer-center {
   text-align: center;
   flex: 1 0 auto;


### PR DESCRIPTION
## Resumen
- favicon actualizado para usar `features/logo.png`
- se muestra el logo en el pie de página
- se añadió un estilo básico para `.footer-logo`

## Testing
- `npm test` *(falla: no existe package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685a9a8c93e88330ac98355a584f7304