### PR TITLE
Add GitHub repo list without removing original content

### DIFF
--- a/app.js
+++ b/app.js
@@ -94,6 +94,38 @@ function animateBubbles() {
 }
 animateBubbles();
 
+async function fetchRepos() {
+    const username = 'YerayAR';
+    const container = document.getElementById('repo-list');
+    if (!container) return;
+    try {
+        const res = await fetch(`https://api.github.com/users/${username}/repos?per_page=100`);
+        if (!res.ok) throw new Error('request failed');
+        const repos = await res.json();
+        for (const repo of repos) {
+            let desc = repo.description || '';
+            try {
+                const readmeRes = await fetch(`https://api.github.com/repos/${username}/${repo.name}/readme`, {
+                    headers: { 'Accept': 'application/vnd.github.v3.raw' }
+                });
+                if (readmeRes.ok) {
+                    const text = await readmeRes.text();
+                    const first = text.split('\n')[0];
+                    if (first) desc = first;
+                }
+            } catch (e) {
+                console.error(e);
+            }
+            const div = document.createElement('div');
+            div.className = 'repo-item';
+            div.innerHTML = `<h3><a href="${repo.html_url}" target="_blank" rel="noopener">${repo.name}</a></h3><p>${desc}</p>`;
+            container.appendChild(div);
+        }
+    } catch (e) {
+        container.textContent = 'No se pudieron cargar los repositorios.';
+    }
+}
+
 // === Contador de visitas local ===
 document.addEventListener('DOMContentLoaded', () => {
     const counter = document.getElementById('visitCount');
@@ -112,4 +144,6 @@ document.addEventListener('DOMContentLoaded', () => {
             mainNav.classList.toggle('hidden');
         });
     }
+
+    fetchRepos();
 });

--- a/index.html
+++ b/index.html
@@ -140,6 +140,9 @@
         <p><a href="https://github.com/YerayAR/ShieldLink" target="_blank" rel="noopener">Ver código en GitHub</a></p>
       </div>
     </div>
+
+    <h3>Repositorios en GitHub</h3>
+    <div id="repo-list"></div>
   </section>
 
   <div class="neon-separator"></div>

--- a/style.css
+++ b/style.css
@@ -453,3 +453,30 @@ footer {
   display: block;
   font-family: var(--font-headings);
 }
+
+/* === Repositorios de GitHub === */
+#repo-list {
+  margin-top: 1rem;
+}
+
+.repo-item {
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid var(--accent-color);
+  border-radius: 5px;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.repo-item h3 {
+  margin: 0 0 0.5rem;
+  color: var(--accent-color);
+}
+
+.repo-item a {
+  color: var(--accent-color);
+  text-decoration: none;
+}
+
+.repo-item a:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- revert previous simplification so original portfolio layout stays intact
- insert automatic GitHub repository list in the Projects section
- style new repo list and load repos dynamically via JavaScript

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685c4f8fbe0c83309bf32fa524e8b9a2